### PR TITLE
🔥 REMOVE the default_app_config definition

### DIFF
--- a/src/organizations/__init__.py
+++ b/src/organizations/__init__.py
@@ -4,6 +4,3 @@
 __author__ = "Ben Lopatin"
 __email__ = "ben@benlopatin.com"
 __version__ = "2.0.1"
-
-
-default_app_config = "organizations.apps.OrganizationsConfig"


### PR DESCRIPTION
Removing this is because to overcome the RemovedInDjango41Warning